### PR TITLE
Mention dockerpi in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,14 @@ The QEMU command line will look like
 with the paths to the disk image, `.dtb` file and kernel image adjusted
 appropriately.
 
+There is a Docker image available to automate this whole process:
+
+```
+docker run -it lukechilds/dockerpi
+```
+
+More information: https://github.com/lukechilds/dockerpi
+
 ## Using kernel images with libvirt
 
 Assuming your libvirt version is at least 5.0.0, you can use something like


### PR DESCRIPTION
Thanks so much for this repo, it's a great resource!

I used it to build https://github.com/lukechilds/dockerpi so I can test code in a Raspberry Pi environment with a single command.

It automates everything described in this repo down to just:

```
docker run -it lukechilds/dockerpi
```

I thought maybe it might be useful to mention it in the readme for others to use.